### PR TITLE
Fix type signatures

### DIFF
--- a/src/ts/database.ts
+++ b/src/ts/database.ts
@@ -114,7 +114,7 @@ namespace Module {
         static prepare2(pDb: ptr<sqlite3>, sql: string): DatabasePrepareResult {
 
             const stack = stackSave()
-            const ppStatement = stackAlloc<ptr<sqlite3>>(4)
+            const ppStatement = stackAlloc<ptr<sqlite3_stmt>>(4)
             const ppTail = stackAlloc<ptr<string>>(4)
 
             var lengthSql = Module.lengthBytesUTF8(sql);
@@ -133,7 +133,7 @@ namespace Module {
                 const statementHandle = Module["getValue"](ppStatement, "*")
                 stackRestore(stack)
 
-                return new DatabasePrepareResult(statementHandle as ptr<sqlite3>, code, tailIndex);
+                return new DatabasePrepareResult(statementHandle as ptr<sqlite3_stmt>, code, tailIndex);
             }
             finally {
                 Module._free(pSql);
@@ -182,69 +182,69 @@ namespace Module {
         //
         // Statement-related apis
         //
-        static column_count(pStatement: ptr<sqlite3>): number {
+        static column_count(pStatement: ptr<sqlite3_stmt>): number {
             return sqlite3_column_count(pStatement);
         }
 
-        static bind_parameter_count(pStatement: ptr<sqlite3>): number {
+        static bind_parameter_count(pStatement: ptr<sqlite3_stmt>): number {
             return sqlite3_bind_parameter_count(pStatement);
         }
 
-        static step(pStatement: ptr<sqlite3>): SQLiteResult {
+        static step(pStatement: ptr<sqlite3_stmt>): SQLiteResult {
             return sqlite3_step(pStatement);
         }
 
-        static stmt_readonly(pStatement: ptr<sqlite3>): SQLiteResult {
+        static stmt_readonly(pStatement: ptr<sqlite3_stmt>): SQLiteResult {
             return sqlite3_stmt_readonly(pStatement);
         }
 
-        static finalize(pStatement: ptr<sqlite3>): SQLiteResult {
+        static finalize(pStatement: ptr<sqlite3_stmt>): SQLiteResult {
             var res = sqlite3_finalize(pStatement);
             Database.persist();
             return res;
         }
 
-        static reset(pStatement: ptr<sqlite3>): SQLiteResult {
+        static reset(pStatement: ptr<sqlite3_stmt>): SQLiteResult {
             return sqlite3_reset(pStatement);
         }
 
-        static column_name(pStatement: ptr<sqlite3>, index: number): string {
+        static column_name(pStatement: ptr<sqlite3_stmt>, index: number): string {
             return sqlite3_column_name(pStatement, index);
         }
 
-        static column_type(pStatement: ptr<sqlite3>, index: number): number {
+        static column_type(pStatement: ptr<sqlite3_stmt>, index: number): number {
             return sqlite3_column_type(pStatement, index);
         }
 
-        static column_bytes(pStatement: ptr<sqlite3>, index: number): number {
+        static column_bytes(pStatement: ptr<sqlite3_stmt>, index: number): number {
             return sqlite3_column_bytes(pStatement, index);
         }
 
-        static bind_text(pStatement: ptr<sqlite3>, index: number, value: string): SQLiteResult {
+        static bind_text(pStatement: ptr<sqlite3_stmt>, index: number, value: string): SQLiteResult {
             return sqlite3_bind_text(pStatement, index, value, -1, <ptr<sqlite3>>-1);
         }
 
-        static bind_int(pStatement: ptr<sqlite3>, index: number, value: number): SQLiteResult {
+        static bind_int(pStatement: ptr<sqlite3_stmt>, index: number, value: number): SQLiteResult {
             return sqlite3_bind_int(pStatement, index, value);
         }
 
-        static bind_int64(pStatement: ptr<sqlite3>, index: number, value: Uint8Array): SQLiteResult {
+        static bind_int64(pStatement: ptr<sqlite3_stmt>, index: number, value: Uint8Array): SQLiteResult {
             return sqlite3_bind_int64ptr(pStatement, index, value);
         }
 
-        static bind_double(pStatement: ptr<sqlite3>, index: number, value: number): SQLiteResult {
+        static bind_double(pStatement: ptr<sqlite3_stmt>, index: number, value: number): SQLiteResult {
             return sqlite3_bind_double(pStatement, index, value);
         }
 
-        static bind_null(pStatement: ptr<sqlite3>, index: number): SQLiteResult {
+        static bind_null(pStatement: ptr<sqlite3_stmt>, index: number): SQLiteResult {
             return sqlite3_bind_null(pStatement, index);
         }
 
-        static bind_parameter_index(pStatement: ptr<sqlite3>, name: string): number {
+        static bind_parameter_index(pStatement: ptr<sqlite3_stmt>, name: string): number {
             return sqlite3_bind_parameter_index(pStatement, name);
         }
 
-        static bind_blob(pStatement: ptr<sqlite3>, index: number, value: Uint8Array, length: number): SQLiteResult {
+        static bind_blob(pStatement: ptr<sqlite3_stmt>, index: number, value: Uint8Array, length: number): SQLiteResult {
 
             var data = Module._malloc(length);
 
@@ -260,15 +260,15 @@ namespace Module {
             }
         }
 
-        static column_int(pStatement: ptr<sqlite3>, index: number): number {
+        static column_int(pStatement: ptr<sqlite3_stmt>, index: number): number {
             return sqlite3_column_int(pStatement, index);
         }
 
-        static column_double(pStatement: ptr<sqlite3>, index: number): number {
+        static column_double(pStatement: ptr<sqlite3_stmt>, index: number): number {
             return sqlite3_column_double(pStatement, index);
         }
 
-        static column_int64ptr(pStatement: ptr<sqlite3>, index: number): Uint8Array {
+        static column_int64ptr(pStatement: ptr<sqlite3_stmt>, index: number): Uint8Array {
 
             var data = Module._malloc(8);
 
@@ -287,7 +287,7 @@ namespace Module {
             }
         }
 
-        static column_blob(pStatement: ptr<sqlite3>, index: number): Uint8Array {
+        static column_blob(pStatement: ptr<sqlite3_stmt>, index: number): Uint8Array {
             var ptr = sqlite3_column_blob(pStatement, index);
             var size = sqlite3_column_bytes(pStatement, index);
 
@@ -300,7 +300,7 @@ namespace Module {
             return output;
         }
 
-        static column_text(pStatement: ptr<sqlite3>, index: number): string {
+        static column_text(pStatement: ptr<sqlite3_stmt>, index: number): string {
             return sqlite3_column_text(pStatement, index);
         }
 
@@ -344,11 +344,11 @@ namespace Module {
     }
 
     export class DatabasePrepareResult {
-        public readonly pStatement: ptr<sqlite3>;
+        public readonly pStatement: ptr<sqlite3_stmt>;
         public readonly Result: SQLiteResult;
         public readonly TailIndex: number;
 
-        constructor(pStatement: ptr<sqlite3>, result: SQLiteResult, tailIndex: number) {
+        constructor(pStatement: ptr<sqlite3_stmt>, result: SQLiteResult, tailIndex: number) {
             this.Result = result;
             this.pStatement = pStatement;
             this.TailIndex = tailIndex;

--- a/src/ts/sqlite-functions.ts
+++ b/src/ts/sqlite-functions.ts
@@ -40,95 +40,95 @@ namespace Module {
         = Module["cwrap"]("sqlite3_errmsg", "string", ["number"])
 
     export const sqlite3_prepare2
-        : (pDb: ptr<sqlite3>, pSql: ptr<string>, numBytes: number, pStatement: ptr<ptr<sqlite3>>, pzTail: ptr<ptr<string>>) => SQLiteResult
+        : (pDb: ptr<sqlite3>, pSql: ptr<string>, numBytes: number, pStatement: ptr<ptr<sqlite3_stmt>>, pzTail: ptr<ptr<string>>) => SQLiteResult
         = Module["cwrap"]("sqlite3_prepare_v2", "number", ["number", "number", "number", "number", "number"])
 
     export const sqlite3_column_count
-        : (pStatement: ptr<sqlite3>) => number
+        : (pStatement: ptr<sqlite3_stmt>) => number
         = Module["cwrap"]("sqlite3_column_count", "number", ["number"])
 
     export const sqlite3_step
-        : (pStatement: ptr<sqlite3>) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>) => SQLiteResult
         = Module["cwrap"]("sqlite3_step", "number", ["number"])
 
     export const sqlite3_stmt_readonly
-        : (pStatement: ptr<sqlite3>) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>) => SQLiteResult
         = Module["cwrap"]("sqlite3_stmt_readonly", "number", ["number"])
 
     export const sqlite3_bind_parameter_count
-        : (pStatement: ptr<sqlite3>) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_parameter_count", "number", ["number"])
 
     export const sqlite3_finalize
-        : (pStatement: ptr<sqlite3>) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>) => SQLiteResult
         = Module["cwrap"]("sqlite3_finalize", "number", ["number"])
 
     export const sqlite3_reset
-        : (pStatement: ptr<sqlite3>) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>) => SQLiteResult
         = Module["cwrap"]("sqlite3_reset", "number", ["number"])
 
     export const sqlite3_column_name
-        : (pStatement: ptr<sqlite3>, index: number) => string
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => string
         = Module["cwrap"]("sqlite3_column_name", "string", ["number", "number"])
 
     export const sqlite3_column_type
-        : (pStatement: ptr<sqlite3>, index: number) => number
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => number
         = Module["cwrap"]("sqlite3_column_type", "number", ["number", "number"])
 
     export const sqlite3_column_int
-        : (pStatement: ptr<sqlite3>, index: number) => number
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => number
         = Module["cwrap"]("sqlite3_column_int", "number", ["number", "number"])
 
     export const sqlite3_column_bytes
-        : (pStatement: ptr<sqlite3>, index: number) => number
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => number
         = Module["cwrap"]("sqlite3_column_bytes", "number", ["number", "number"])
 
     export const sqlite3_column_int64ptr
-        : (pStatement: ptr<sqlite3>, index: number, pOutValue: number) => void
+        : (pStatement: ptr<sqlite3_stmt>, index: number, pOutValue: number) => void
         = Module["cwrap"]("sqlite3_column_int64ptr", "number", ["number", "number", "number"])
 
     export const sqlite3_column_double
-        : (pStatement: ptr<sqlite3>, index: number) => number
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => number
         = Module["cwrap"]("sqlite3_column_double", "number", ["number", "number"])
 
     export const sqlite3_column_text
-        : (pStatement: ptr<sqlite3>, index: number) => string
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => string
         = Module["cwrap"]("sqlite3_column_text", "string", ["number", "number"])
 
     export const sqlite3_column_blob
-        : (pStatement: ptr<sqlite3>, index: number) => number
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => number
         = Module["cwrap"]("sqlite3_column_blob", "number", ["number", "number"])
 
     export const sqlite3_bind_text
-        : (pStatement: ptr<sqlite3>, index: number, val: string, n: number, pFree: ptr<sqlite3>) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>, index: number, val: string, n: number, pFree: ptr<sqlite3>) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_text", "number", ["number", "number", "string", "number", "number"])
 
     export const sqlite3_bind_int
-        : (pStatement: ptr<sqlite3>, index: number, val: number) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>, index: number, val: number) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_int", "number", ["number", "number", "number"])
 
     export const sqlite3_bind_int64ptr
-        : (pStatement: ptr<sqlite3>, index: number, val: Uint8Array) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>, index: number, val: Uint8Array) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_int64ptr", "number", ["number", "number", "array"])
 
     export const sqlite3_bind_double
-        : (pStatement: ptr<sqlite3>, index: number, val: number) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>, index: number, val: number) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_double", "number", ["number", "number", "number"])
 
     export const sqlite3_bind_null
-        : (pStatement: ptr<sqlite3>, index: number) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>, index: number) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_null", "number", ["number", "number"])
 
     export const sqlite3_bind_parameter_index
-        : (pStatement: ptr<sqlite3>, name: string) => number
+        : (pStatement: ptr<sqlite3_stmt>, name: string) => number
         = Module["cwrap"]("sqlite3_bind_parameter_index", "number", ["number", "string"])
 
     export const sqlite3_bind_blob
-        : (pStatement: ptr<sqlite3>, index: number, value: number, length: number, pCallback: number) => SQLiteResult
+        : (pStatement: ptr<sqlite3_stmt>, index: number, value: number, length: number, pCallback: number) => SQLiteResult
         = Module["cwrap"]("sqlite3_bind_blob", "number", ["number", "number", "number", "number", "number"])
 
     export const sqlite3_changes
-        : (pStatement: ptr<sqlite3>) => number
+        : (pDb: ptr<sqlite3>) => number
         = Module["cwrap"]("sqlite3_changes", "number", ["number"])
 
     export const sqlite3_close_v2

--- a/src/ts/sqlite-objects.ts
+++ b/src/ts/sqlite-objects.ts
@@ -1,4 +1,5 @@
 namespace Module {
     export type sqlite3_ptr<T> = ptr<T> & { __free__: "sqlite3_free" }
     export interface sqlite3 { __type__: "sqlite3" }
+    export interface sqlite3_stmt { __type__: "sqlite3_stmt" }
 }


### PR DESCRIPTION
This patch brings more proper typing of `sqlite3_stmt` objects:
- Add an interface representing [`struct sqlite3_stmt`](https://www.sqlite.org/c3ref/stmt.html)
- Fix type signatures of `pStatement`
- Fix the parameter name of `sqlite3_changes` (`pStatement` to `pDb`)