### PR TITLE
fix: generate .a from .o for older emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,4 +138,4 @@ dist: dist/sqlite3.a
 dist/sqlite3.a: $(BITCODE_FILES) $(EXPORTED_FUNCTIONS_JSON)
 	mkdir -p dist
 	$(EMCC) $(EMFLAGS) $(EMFLAGS_DIST) $(BITCODE_FILES) -r -o sqlite3.o
-	ar rcs sqlite3.a sqlite3.o
+	ar rcs dist/sqlite3.a sqlite3.o

--- a/Makefile
+++ b/Makefile
@@ -137,4 +137,5 @@ dist: dist/sqlite3.a
 # See https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/custom-versions?tabs=netcore-cli#bundles for more details.
 dist/sqlite3.a: $(BITCODE_FILES) $(EXPORTED_FUNCTIONS_JSON)
 	mkdir -p dist
-	$(EMCC) $(EMFLAGS) $(EMFLAGS_DIST) $(BITCODE_FILES) -r -o $@
+	$(EMCC) $(EMFLAGS) $(EMFLAGS_DIST) $(BITCODE_FILES) -r -o sqlite3.o
+	ar rcs sqlite3.a sqlite3.o

--- a/src/nuget/uno.sqlite-wasm.nuspec
+++ b/src/nuget/uno.sqlite-wasm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="5.0.0">
     <id>Uno.sqlite-wasm</id>
-    <version>3.40.0.4</version>
+    <version>3.40.0.5</version>
     <title>Uno SQLite for WebAssembly</title>
     <authors>Uno Platform</authors>
     <owners>unoplatform</owners>


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.sqlite-wasm/issues/33